### PR TITLE
Feature/generate auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ function handler(event, context) {
 
 _Note:_ The errors thrown by authentication start with either `401:` or `403:`, depending on the reason (not matching scope vs having an invalid token). This means the AWS Lambda function results in a string that matches the regex `4\\d{2}:.*`
 
+The authentication submodule also allows generating JWT tokens with the configured settings. This is meant to be used as a means for generating a temporary token that can be used by the service for communication with another service. This should not be used as the main means for generating tokens distributed to users. In general it is preferable to pass along the token that was received from the user, but in cases where there is no end-user (such as a periodic task), this functionality allows creating a token for service-to-service requests.
+
 ### Service Discovery
 
 At the root of every microservice should be a discovery method for publicly accessible resources. Generally the structure of this discovery response is very similar between various services, which the Foundation aims to simplify. Furthermore, all services also rely on similar code for resolving/completing the HREFs present in the responses.

--- a/lib/authentication/index.js
+++ b/lib/authentication/index.js
@@ -29,6 +29,31 @@ module.exports = {
     },
 
     /**
+     * Generate a token using the same secret as with verifying
+     *
+     * @param {string} subject of the token (sub)
+     * @param {Array<String> or String} scopes to embed in the token
+     * @param {int} expiresIn - Expiration in seconds, if not given, does not expire
+     */
+    generateToken: function(subject, scopes, expiresIn) {
+        const payload = {
+            scope: _.isArray(scopes) ? scopes : [scopes]
+        };
+
+        const options = {
+            subject: subject,
+            alg: 'HS256'
+        };
+
+        if (expiresIn) {
+            options.expiresIn = expiresIn;
+        }
+
+        const secret = config.secret || process.env.AUTH_SECRET || 'default_secret';
+        return jwt.sign(payload, secret, options);
+    },
+
+    /**
      * Checks if jwt token is valid
      *
      * @param string token - jwt token to be validated
@@ -48,7 +73,7 @@ module.exports = {
         try {
             const secret = config.secret || process.env.AUTH_SECRET || 'default_secret';
             const decoded = jwt.verify(token, secret, {
-                algorithms: ["HS256"]
+                algorithms: ['HS256']
             });
 
             return decoded;

--- a/lib/authentication/index.js
+++ b/lib/authentication/index.js
@@ -30,12 +30,15 @@ module.exports = {
 
     /**
      * Generate a token using the same secret as with verifying
+     * NOTE: THIS API IS TEMPORARY, AND WILL BE SUPPORTED ONLY AS LONG
+     * AS THE SHARED SIGNING SECRET IS USED. AS SOON AS THE ASYMMETRIC APPROACH
+     * IS ADOPTED, THIS API WILL BE DEPRECATED/REMOVED
      *
      * @param {string} subject of the token (sub)
      * @param {Array<String> or String} scopes to embed in the token
      * @param {int} expiresIn - Expiration in seconds, if not given, does not expire
      */
-    generateToken: function(subject, scopes, expiresIn) {
+    getToken: function(subject, scopes, expiresIn) {
         const payload = {
             scope: _.isArray(scopes) ? scopes : [scopes]
         };

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -197,3 +197,58 @@ tape.test('if valid token and invalid scope then false', function(t) {
         t.end();
     });
 });
+
+tape.test('If generating a token, returns a valid token', function(t) {
+    const token = auth.generateToken('test@testlio.com', 'tester');
+
+    // Validate by immediately running the same token through auth
+    const authPromise = auth.authenticate(token, {
+        scope: ['tester']
+    });
+
+    authPromise.then(function(jwt) {
+        // Validate the contents
+        t.equal(jwt.sub, 'test@testlio.com', 'Resulting token has invalid subject');
+        t.looseEqual(jwt.scope, ['tester'], 'Resulting token has invalid scope');
+        t.notOk(jwt.exp, 'Resulting token should not expire');
+        t.end();
+    }).catch(function(err) {
+        t.fail('Generated an invalid token', err);
+    });
+});
+
+tape.test('If generating a token with multiple scopes, returns a valid token', function(t) {
+    const token = auth.generateToken('test@testlio.com', ['tester', 'admin']);
+
+    // Validate by immediately running the same token through auth
+    const authPromise = auth.authenticate(token);
+
+    authPromise.then(function(jwt) {
+        // Validate the contents
+        t.equal(jwt.sub, 'test@testlio.com', 'Resulting token has invalid subject');
+        t.looseEqual(jwt.scope, ['tester', 'admin'], 'Resulting token has invalid scope');
+        t.notOk(jwt.exp, 'Resulting token should not expire');
+        t.end();
+    }).catch(function(err) {
+        t.fail('Generated an invalid token', err);
+    });
+});
+
+tape.test('If generating a token with expiration, returns a valid token', function(t) {
+    const token = auth.generateToken('test@testlio.com', 'tester', 300);
+
+    // Validate by immediately running the same token through auth
+    const authPromise = auth.authenticate(token, {
+        scope: ['tester']
+    });
+
+    authPromise.then(function(jwt) {
+        // Validate the contents
+        t.equal(jwt.sub, 'test@testlio.com', 'Resulting token has invalid subject');
+        t.looseEqual(jwt.scope, ['tester'], 'Resulting token has invalid scope');
+        t.equal(jwt.exp - jwt.iat, 300, 'Resulting token should expire in correct time');
+        t.end();
+    }).catch(function(err) {
+        t.fail('Generated an invalid token', err);
+    });
+});

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -199,7 +199,7 @@ tape.test('if valid token and invalid scope then false', function(t) {
 });
 
 tape.test('If generating a token, returns a valid token', function(t) {
-    const token = auth.generateToken('test@testlio.com', 'tester');
+    const token = auth.getToken('test@testlio.com', 'tester');
 
     // Validate by immediately running the same token through auth
     const authPromise = auth.authenticate(token, {
@@ -218,7 +218,7 @@ tape.test('If generating a token, returns a valid token', function(t) {
 });
 
 tape.test('If generating a token with multiple scopes, returns a valid token', function(t) {
-    const token = auth.generateToken('test@testlio.com', ['tester', 'admin']);
+    const token = auth.getToken('test@testlio.com', ['tester', 'admin']);
 
     // Validate by immediately running the same token through auth
     const authPromise = auth.authenticate(token);
@@ -235,7 +235,7 @@ tape.test('If generating a token with multiple scopes, returns a valid token', f
 });
 
 tape.test('If generating a token with expiration, returns a valid token', function(t) {
-    const token = auth.generateToken('test@testlio.com', 'tester', 300);
+    const token = auth.getToken('test@testlio.com', 'tester', 300);
 
     // Validate by immediately running the same token through auth
     const authPromise = auth.authenticate(token, {


### PR DESCRIPTION
- [X] Issue exists - Internal
- [X] Linter passes (`npm run lint`)
- [X] Tests pass (`npm run test`)
- [X] CircleCI build is green
- [X] Documentation is up to date (README + comments)

Brief overview of changes:
- Add API for generating tokens in the authentication submodule, this uses the same configuration as verification does
- Added tests and updated documentation for the new functionality