### PR TITLE
Allow reporting extra data along with the error

### DIFF
--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -34,7 +34,7 @@ function report(error, additionalTags, extra) {
         return new Promise(function(resolve) {
             const sentError = error.nativeError ? error.nativeError : error;
 
-            Raygun.send(sentError, _.merge(extra || {}, error.extra), function(res) {
+            Raygun.send(sentError, _.merge(extra || {}, error.extra), function(res) {
                 // No response === stubbed Raygun
                 if (res) {
                     if (res.statusCode !== 202) {

--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -3,14 +3,13 @@
 const Raygun = require('./raygun.js');
 const Promise = require('promiscuous');
 const Config = require('../configuration');
+const _ = require('lodash');
 
 let tags = [];
 
 if (Config.project && Config.project.name) {
     tags = tags.concat(Config.project.name);
-}
-
-if (Config.aws && Config.aws.projectName) {
+} else if (Config.aws && Config.aws.projectName) {
     tags = tags.concat(Config.aws.projectName);
 }
 
@@ -18,11 +17,12 @@ if (Config.aws && Config.aws.projectName) {
  * Report an error, with optional additional tags
  *
  * @param error - error to report
+ * @param extra - extra metadata to include in the error report
  * @param additionalTags - optional additional tags to report, along with the
  *                          default set of tags set on the module
  * @returns promise which resolves into the passed in error
  */
-function report(error, additionalTags) {
+function report(error, extra, additionalTags) {
     let sentTags = tags ? [].concat(tags) : [];
 
     if (additionalTags) {
@@ -34,7 +34,7 @@ function report(error, additionalTags) {
         return new Promise(function(resolve) {
             const sentError = error.nativeError ? error.nativeError : error;
 
-            Raygun.send(sentError, error.extra, function(res) {
+            Raygun.send(sentError, _.merge(extra, error.extra), function(res) {
                 // No response === stubbed Raygun
                 if (res) {
                     if (res.statusCode !== 202) {

--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -17,12 +17,12 @@ if (Config.project && Config.project.name) {
  * Report an error, with optional additional tags
  *
  * @param error - error to report
- * @param extra - extra metadata to include in the error report
  * @param additionalTags - optional additional tags to report, along with the
  *                          default set of tags set on the module
+ * @param extra - extra metadata to include in the error report
  * @returns promise which resolves into the passed in error
  */
-function report(error, extra, additionalTags) {
+function report(error, additionalTags, extra) {
     let sentTags = tags ? [].concat(tags) : [];
 
     if (additionalTags) {

--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -34,7 +34,7 @@ function report(error, additionalTags, extra) {
         return new Promise(function(resolve) {
             const sentError = error.nativeError ? error.nativeError : error;
 
-            Raygun.send(sentError, _.merge(extra, error.extra), function(res) {
+            Raygun.send(sentError, _.merge(extra || {}, error.extra), function(res) {
                 // No response === stubbed Raygun
                 if (res) {
                     if (res.statusCode !== 202) {

--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -19,7 +19,7 @@ if (Config.project && Config.project.name) {
  * @param error - error to report
  * @param additionalTags - optional additional tags to report, along with the
  *                          default set of tags set on the module
- * @param extra - extra metadata to include in the error report
+ * @param extra - optional extra metadata to include in the error report
  * @returns promise which resolves into the passed in error
  */
 function report(error, additionalTags, extra) {

--- a/test/error-test.js
+++ b/test/error-test.js
@@ -62,7 +62,7 @@ tape.test('Error sent to Raygun with additional metadata', function(t) {
         cb();
     };
 
-    LambdaError.report(error, expectedAdditionalExtra).then(function() {
+    LambdaError.report(error, undefined, expectedAdditionalExtra).then(function() {
         t.end();
     });
 });

--- a/test/error-test.js
+++ b/test/error-test.js
@@ -36,6 +36,7 @@ tape.test('Error sent to Raygun', function(t) {
         t.same(actualError, expectedError, 'Error reported to Raygun');
         t.same(actualExtra, expectedExtra, 'Extras reported to Raygun');
         t.same(actualRequest, expectedRequest, 'Request reported to Raygun');
+        t.same(actualTags, ['TEST'], 'Tags reported to Raygun');
         cb();
     };
 
@@ -55,10 +56,11 @@ tape.test('Error sent to Raygun with additional metadata', function(t) {
     const expectedError = new Error(expectedCode + ': ' + expectedMessage);
     const error = new LambdaError(expectedCode, expectedMessage, expectedExtra, expectedRequest);
 
-    Raygun.send = function(actualError, actualExtra, cb, actualRequest) {
+    Raygun.send = function(actualError, actualExtra, cb, actualRequest, actualTags) {
         t.same(actualError, expectedError, 'Error reported to Raygun');
         t.same(actualExtra, _.merge(expectedAdditionalExtra, expectedExtra), 'Extras reported to Raygun');
         t.same(actualRequest, expectedRequest, 'Request reported to Raygun');
+        t.same(actualTags, ['TEST'], 'Tags reported to Raygun');
         cb();
     };
 
@@ -82,7 +84,7 @@ tape.test('Error sent to Raygun with additional tags', function(t) {
         t.same(actualError, expectedError, 'Error reported to Raygun');
         t.same(actualExtra, expectedExtra, 'Extras reported to Raygun');
         t.same(actualRequest, expectedRequest, 'Request reported to Raygun');
-        t.same(actualTags, ['TEST'].concat(expectedAdditionalTags));
+        t.same(actualTags, ['TEST'].concat(expectedAdditionalTags), 'Tags reported to Raygun');
         cb();
     };
 

--- a/test/error-test.js
+++ b/test/error-test.js
@@ -32,7 +32,7 @@ tape.test('Error sent to Raygun', function(t) {
     const expectedError = new Error(expectedCode + ': ' + expectedMessage);
     const error = new LambdaError(expectedCode, expectedMessage, expectedExtra, expectedRequest);
 
-    Raygun.send = function(actualError, actualExtra, cb, actualRequest) {
+    Raygun.send = function(actualError, actualExtra, cb, actualRequest, actualTags) {
         t.same(actualError, expectedError, 'Error reported to Raygun');
         t.same(actualExtra, expectedExtra, 'Extras reported to Raygun');
         t.same(actualRequest, expectedRequest, 'Request reported to Raygun');

--- a/test/error-test.js
+++ b/test/error-test.js
@@ -67,6 +67,30 @@ tape.test('Error sent to Raygun with additional metadata', function(t) {
     });
 });
 
+tape.test('Error sent to Raygun with additional tags', function(t) {
+    const expectedCode = 401;
+    const expectedMessage = 'A serious error happened';
+    const expectedExtra = {'id': 123};
+    const expectedRequest = {'request':'caused error'};
+    const expectedAdditionalTags = ['foo', 'bar'];
+
+    // The error that is sent through is a native one
+    const expectedError = new Error(expectedCode + ': ' + expectedMessage);
+    const error = new LambdaError(expectedCode, expectedMessage, expectedExtra, expectedRequest);
+
+    Raygun.send = function(actualError, actualExtra, cb, actualRequest, actualTags) {
+        t.same(actualError, expectedError, 'Error reported to Raygun');
+        t.same(actualExtra, expectedExtra, 'Extras reported to Raygun');
+        t.same(actualRequest, expectedRequest, 'Request reported to Raygun');
+        t.same(actualTags, ['TEST'].concat(expectedAdditionalTags));
+        cb();
+    };
+
+    LambdaError.report(error, expectedAdditionalTags).then(function() {
+        t.end();
+    });
+});
+
 tape.test('Error reporting failure resolves to error', function(t) {
     const expectedCode = 401;
     const expectedMessage = 'A serious error happened';

--- a/test/error-test.js
+++ b/test/error-test.js
@@ -3,6 +3,7 @@
 const tape = require('tape');
 const LambdaError = require('../lib/error');
 const Raygun = require('../lib/error/raygun.js');
+const _ = require('lodash');
 
 // Add a TEST tag to our errors
 LambdaError.config({
@@ -33,12 +34,35 @@ tape.test('Error sent to Raygun', function(t) {
 
     Raygun.send = function(actualError, actualExtra, cb, actualRequest) {
         t.same(actualError, expectedError, 'Error reported to Raygun');
-        t.equal(actualExtra, expectedExtra, 'Extras reported to Raygun');
-        t.equal(actualRequest, expectedRequest, 'Request reported to Raygun');
+        t.same(actualExtra, expectedExtra, 'Extras reported to Raygun');
+        t.same(actualRequest, expectedRequest, 'Request reported to Raygun');
         cb();
     };
 
     LambdaError.report(error).then(function() {
+        t.end();
+    });
+});
+
+tape.test('Error sent to Raygun with additional metadata', function(t) {
+    const expectedCode = 401;
+    const expectedMessage = 'A serious error happened';
+    const expectedExtra = {'id': 123};
+    const expectedRequest = {'request':'caused error'};
+    const expectedAdditionalExtra = {'more': 'foo'};
+
+    // The error that is sent through is a native one
+    const expectedError = new Error(expectedCode + ': ' + expectedMessage);
+    const error = new LambdaError(expectedCode, expectedMessage, expectedExtra, expectedRequest);
+
+    Raygun.send = function(actualError, actualExtra, cb, actualRequest) {
+        t.same(actualError, expectedError, 'Error reported to Raygun');
+        t.same(actualExtra, _.merge(expectedAdditionalExtra, expectedExtra), 'Extras reported to Raygun');
+        t.same(actualRequest, expectedRequest, 'Request reported to Raygun');
+        cb();
+    };
+
+    LambdaError.report(error, expectedAdditionalExtra).then(function() {
         t.end();
     });
 });


### PR DESCRIPTION
- [ ] Issue exists
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Added a further parameter to error reporting, which allows sending additional metadata in addition to data already on the error.
- This should help with passing along information about the request, context and event to the error report.
- Improved test coverage of the error submodule