### PR TITLE
Bugfix/authentication test

### DIFF
--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -177,7 +177,7 @@ tape.test('if valid token and valid scope then resolve decoded token', function(
     });
 });
 
-tape.test('if invalid token and valid scope then false', function(t) {
+tape.test('if invalid token and valid scope then reject', function(t) {
 
     const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34' + 'foo', {
         scope: ['admin'],
@@ -194,7 +194,7 @@ tape.test('if invalid token and valid scope then false', function(t) {
     });
 });
 
-tape.test('if valid token and invalid scope then false', function(t) {
+tape.test('if valid token and invalid scope then reject', function(t) {
 
     const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34', {
         scope: ['admin']

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -154,15 +154,27 @@ tape.test('if no unallowed roles present with None rule then return true', funct
     t.end();
 });
 
-tape.test('if valid token and valid scope then return true', function(t) {
+tape.test('if valid token and valid scope then resolve decoded token', function(t) {
 
-    const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGVzIjpbInRlc3RlciJdfQ.MjK579tyUaxtY9FXpTktC-vssI-rOS1RNsGl8KWX9mM', {
+    const expectedDecodedToken = {
+        'sub': 'test@test.com',
+        'scope': [
+            'tester'
+        ]
+    };
+
+    const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34', {
         scope: ['admin'],
         rule: auth.RULE.NONE
     });
 
-    t.ok(authPromise, 'true expected');
-    t.end();
+    authPromise.then(function(decodedToken) {
+        t.deepEqual(expectedDecodedToken, decodedToken, 'decoded token doesn\'t match');
+        t.end();
+    }).catch(function(err) {
+        t.fail(err.message);
+        t.end();
+    });
 });
 
 tape.test('if invalid token and valid scope then false', function(t) {

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -34,7 +34,7 @@ tape.test('If invalid token then return 401', function(t) {
 tape.test('If valid token then return decoded token', function(t) {
 
     try {
-        const decoded = auth.isValidToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGVzIjpbInRlc3RlciJdfQ.MjK579tyUaxtY9FXpTktC-vssI-rOS1RNsGl8KWX9mM');
+        const decoded = auth.isValidToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34');
         t.equal(decoded.sub, 'test@test.com');
         t.end();
     } catch (err) {
@@ -71,7 +71,7 @@ tape.test('If valid token with altered secret then return decoded token', functi
 tape.test('If valid token with Bearer keyword then return decoded token', function(t) {
 
     try {
-        const decoded = auth.isValidToken('Bearer ' + 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGVzIjpbInRlc3RlciJdfQ.MjK579tyUaxtY9FXpTktC-vssI-rOS1RNsGl8KWX9mM');
+        const decoded = auth.isValidToken('Bearer ' + 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34');
         t.equal(decoded.sub, 'test@test.com');
         t.end();
     } catch (err) {
@@ -179,7 +179,7 @@ tape.test('if valid token and valid scope then resolve decoded token', function(
 
 tape.test('if invalid token and valid scope then false', function(t) {
 
-    const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGVzIjpbInRlc3RlciJdfQ.MjK579tyUaxtY9FXpTktC-vssI-rOS1RNsGl8KWX9mM' + 'foo', {
+    const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34' + 'foo', {
         scope: ['admin'],
         rule: auth.RULE.NONE
     });
@@ -196,8 +196,8 @@ tape.test('if invalid token and valid scope then false', function(t) {
 
 tape.test('if valid token and invalid scope then false', function(t) {
 
-    const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGVzIjpbInRlc3RlciJdfQ.MjK579tyUaxtY9FXpTktC-vssI-rOS1RNsGl8KWX9mM', {
-        scope: ['tester']
+    const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34', {
+        scope: ['admin']
     });
 
     authPromise.then(function() {

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -180,7 +180,7 @@ tape.test('if valid token and valid scope then resolve decoded token', function(
 tape.test('if invalid token and valid scope then reject', function(t) {
 
     const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34' + 'foo', {
-        scope: ['admin'],
+        scope: ['tester'],
         rule: auth.RULE.NONE
     });
 


### PR DESCRIPTION
- [ ] Issue exists
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Authenticate test with valid token and scope was not actually asserting anything
- The valid token used in tests had scopes under the wrong claim ("scopes" vs "scope")

![](http://i.giphy.com/SEp6Zq6ZkzUNW.gif)