### PR TITLE
Bugfix/error equal assertion

### DIFF
--- a/lib/test/context.js
+++ b/lib/test/context.js
@@ -72,7 +72,12 @@ module.exports = {
             fail: function(err) {
                 t.ok(true, 'Context finished with failure');
                 if (expected) {
-                    t.same(err, expected, 'Context failed with expected result');
+                    if (err instanceof Error && err.name !== 'LambdaError') {
+                        t.same(err.name, expected.name, 'Context failed with expected error type');
+                        t.same(err.message, expected.message, 'Context failed with expected error message');
+                    } else {
+                        t.same(err, expected, 'Context failed with expected result');
+                    }
                 }
                 if(cb) {
                     cb(err);

--- a/test/mock-context-test.js
+++ b/test/mock-context-test.js
@@ -1,5 +1,5 @@
 const tape = require('tape');
-const Error = require('../lib/error');
+const FoundationError = require('../lib/error');
 const Context = require('../lib/test/context');
 
 tape.test('Should succeed with expected result provided', function(t) {
@@ -25,31 +25,31 @@ tape.test('Should succeed with callback provided', function(t) {
 });
 
 tape.test('Should fail with expected error provided', function(t) {
-    const mock = Context.assertFail(t, new Error('999', 'Expected error'));
+    const mock = Context.assertFail(t, new FoundationError('999', 'Expected error'));
     t.plan(2);
-    mock.fail(new Error('999', 'Expected error'));
+    mock.fail(new FoundationError('999', 'Expected error'));
 });
 
 tape.test('Should fail with expected error and callback provided', function(t) {
-    const mock = Context.assertFail(t, new Error('999', 'Expected error'), function(error) {
-        t.same(error, new Error('999', 'Expected error'), 'Callback called');
+    const mock = Context.assertFail(t, new FoundationError('999', 'Expected error'), function(error) {
+        t.same(error, new FoundationError('999', 'Expected error'), 'Callback called');
     });
     t.plan(3);
-    mock.fail(new Error('999', 'Expected error'));
+    mock.fail(new FoundationError('999', 'Expected error'));
 });
 
 tape.test('Should fail with expected error and callback provided', function(t) {
     const mock = Context.assertFail(t, function(error) {
-        t.same(error, new Error('999', 'Expected error'), 'Callback called');
+        t.same(error, new FoundationError('999', 'Expected error'), 'Callback called');
     });
     t.plan(2);
-    mock.fail(new Error('999', 'Expected error'));
+    mock.fail(new FoundationError('999', 'Expected error'));
 });
 
 tape.test('Should succeed with done called', function(t) {
-    const mock = Context.assertFail(t, new Error('999', 'Expected error'));
+    const mock = Context.assertFail(t, new FoundationError('999', 'Expected error'));
     t.plan(2);
-    mock.done(new Error('999', 'Expected error'));
+    mock.done(new FoundationError('999', 'Expected error'));
 });
 
 tape.test('Should succeed with done called', function(t) {

--- a/test/mock-context-test.js
+++ b/test/mock-context-test.js
@@ -57,3 +57,8 @@ tape.test('Should succeed with done called', function(t) {
     t.plan(2);
     mock.done(null, {result:"result"});
 });
+
+tape.test('Should assert that two identical vanilla errors are equal', function(t) {
+    const mock = Context.assertFail(t, new Error('Expected error'));
+    mock.fail(new Error('Expected error'));
+});


### PR DESCRIPTION
- [x] Issue exists - #30 
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Changed test module's behaviour – two Error objects with different messages or error types will no longer be asserted as equal.

In-depth description of problem can be found under the issue.

This change is planned for the v3 major release of Lambda Foundation.

![](https://media.giphy.com/media/3orieYLeAJN6WBUjL2/giphy.gif)
