### PR TITLE
Enforce bearer auth scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var Auth = require('lambda-foundation').authentication;
 
 ### Authentication
 
-Authentication is an asynchronous process, that assumes the event contains a value under the `authorization` key. This value could be a pure OAuth token or it could be a full header (with type prefix). The API returns a promise that fails if the context is not properly authenticated. Upon success, the promise resolves the token into its claims, which in general contain a `sub`, `exp` and `iat` keys as per the [JWT spec](http://jwt.io/introduction/).
+Authentication is an asynchronous process, that assumes the event contains a value under the `authorization` key. This value must be an OAuth Bearer token, as defined in [RFC 6750](https://tools.ietf.org/html/rfc6750). The API returns a promise that fails if the context is not properly authenticated. Upon success, the promise resolves the token into its claims, which in general contain a `sub`, `exp` and `iat` keys as per the [JWT spec](http://jwt.io/introduction/).
 
 ```js
 var Auth = require('lambda-foundation').authentication;

--- a/lib/authentication/index.js
+++ b/lib/authentication/index.js
@@ -38,9 +38,7 @@ module.exports = {
     isValidToken: function(token) {
         if (!token || !_.startsWith(token.toUpperCase(), 'BEARER')) {
             throw new Error('401', 'Invalid token');
-        }
-
-        if (_.startsWith(token, 'Bearer')) {
+        } else {
             token = token.substring(6).trim();
         }
 

--- a/lib/authentication/index.js
+++ b/lib/authentication/index.js
@@ -36,7 +36,7 @@ module.exports = {
      * @throws if token is invalid
      */
     isValidToken: function(token) {
-        if (!token) {
+        if (!token || !_.startsWith(token, 'Bearer')) {
             throw new Error('401', 'Invalid token');
         }
 

--- a/lib/authentication/index.js
+++ b/lib/authentication/index.js
@@ -36,7 +36,7 @@ module.exports = {
      * @throws if token is invalid
      */
     isValidToken: function(token) {
-        if (!token || !_.startsWith(token, 'Bearer')) {
+        if (!token || !_.startsWith(token.toUpperCase(), 'BEARER')) {
             throw new Error('401', 'Invalid token');
         }
 

--- a/lib/test/event.js
+++ b/lib/test/event.js
@@ -28,7 +28,7 @@ module.exports = function (extras){
             payload = _.isString(payload) ? {sub: payload} : payload;
 
             return _.merge(
-                { authorization: jwt.sign(payload, secret) },
+                { authorization: 'Bearer ' + jwt.sign(payload, secret) },
                 properties
             );
         },

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -220,4 +220,4 @@ tape.test('if Bearer prefix is missing then reject', function(t) {
         t.equal(err.code, '401');
         t.end();
     }
-})
+});

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -34,7 +34,7 @@ tape.test('If invalid token then return 401', function(t) {
 tape.test('If valid token then return decoded token', function(t) {
 
     try {
-        const decoded = auth.isValidToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34');
+        const decoded = auth.isValidToken('Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34');
         t.equal(decoded.sub, 'test@test.com');
         t.end();
     } catch (err) {
@@ -71,7 +71,7 @@ tape.test('If valid token with altered secret then return decoded token', functi
 tape.test('If valid token with Bearer keyword then return decoded token', function(t) {
 
     try {
-        const decoded = auth.isValidToken('Bearer ' + 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34');
+        const decoded = auth.isValidToken('Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34');
         t.equal(decoded.sub, 'test@test.com');
         t.end();
     } catch (err) {
@@ -163,7 +163,7 @@ tape.test('if valid token and valid scope then resolve decoded token', function(
         ]
     };
 
-    const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34', {
+    const authPromise = auth.authenticate('Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34', {
         scope: ['admin'],
         rule: auth.RULE.NONE
     });
@@ -179,7 +179,7 @@ tape.test('if valid token and valid scope then resolve decoded token', function(
 
 tape.test('if invalid token and valid scope then reject', function(t) {
 
-    const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34' + 'foo', {
+    const authPromise = auth.authenticate('Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34' + 'foo', {
         scope: ['tester'],
         rule: auth.RULE.NONE
     });
@@ -196,7 +196,7 @@ tape.test('if invalid token and valid scope then reject', function(t) {
 
 tape.test('if valid token and invalid scope then reject', function(t) {
 
-    const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34', {
+    const authPromise = auth.authenticate('Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34', {
         scope: ['admin']
     });
 

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -209,3 +209,15 @@ tape.test('if valid token and invalid scope then reject', function(t) {
         t.end();
     });
 });
+
+tape.test('if Bearer prefix is missing then reject', function(t) {
+    try {
+        auth.isValidToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34');
+
+        t.fail('didn\'t throw error');
+        t.end();
+    } catch (err) {
+        t.equal(err.code, '401');
+        t.end();
+    }
+})


### PR DESCRIPTION
For v3 release.
- [x] Issue exists - #28 
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [ ] Documentation is up to date (README + comments)

Brief overview of changes:
- Require `Bearer` prefix for all authorization tokens

If authorisation token does not begin with `Bearer`, `401 Invalid Token` will be thrown.

Requirement still needs to be documented in README.

![](https://media.giphy.com/media/1F2jXmhuUjhGE/giphy.gif)
