### PR TITLE
Release/v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var Auth = require('lambda-foundation').authentication;
 
 ### Authentication
 
-Authentication is an asynchronous process, that assumes the event contains a value under the `authorization` key. This value could be a pure OAuth token or it could be a full header (with type prefix). The API returns a promise that fails if the context is not properly authenticated. Upon success, the promise resolves the token into its claims, which in general contain a `sub`, `exp` and `iat` keys as per the [JWT spec](http://jwt.io/introduction/).
+Authentication is an asynchronous process, that assumes the event contains a value under the `authorization` key. This value must be an OAuth Bearer token, as defined in [RFC 6750](https://tools.ietf.org/html/rfc6750). The API returns a promise that fails if the context is not properly authenticated. Upon success, the promise resolves the token into its claims, which in general contain a `sub`, `exp` and `iat` keys as per the [JWT spec](http://jwt.io/introduction/).
 
 ```js
 var Auth = require('lambda-foundation').authentication;

--- a/lib/authentication/index.js
+++ b/lib/authentication/index.js
@@ -36,11 +36,9 @@ module.exports = {
      * @throws if token is invalid
      */
     isValidToken: function(token) {
-        if (!token) {
+        if (!token || !_.startsWith(token.toUpperCase(), 'BEARER')) {
             throw new Error('401', 'Invalid token');
-        }
-
-        if (_.startsWith(token, 'Bearer')) {
+        } else {
             token = token.substring(6).trim();
         }
 

--- a/lib/test/context.js
+++ b/lib/test/context.js
@@ -72,7 +72,12 @@ module.exports = {
             fail: function(err) {
                 t.ok(true, 'Context finished with failure');
                 if (expected) {
-                    t.same(err, expected, 'Context failed with expected result');
+                    if (err instanceof Error && err.name !== 'LambdaError') {
+                        t.same(err.name, expected.name, 'Context failed with expected error type');
+                        t.same(err.message, expected.message, 'Context failed with expected error message');
+                    } else {
+                        t.same(err, expected, 'Context failed with expected result');
+                    }
                 }
                 if(cb) {
                     cb(err);

--- a/lib/test/event.js
+++ b/lib/test/event.js
@@ -28,7 +28,7 @@ module.exports = function (extras){
             payload = _.isString(payload) ? {sub: payload} : payload;
 
             return _.merge(
-                { authorization: jwt.sign(payload, secret) },
+                { authorization: 'Bearer ' + jwt.sign(payload, secret) },
                 properties
             );
         },

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -34,7 +34,7 @@ tape.test('If invalid token then return 401', function(t) {
 tape.test('If valid token then return decoded token', function(t) {
 
     try {
-        const decoded = auth.isValidToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34');
+        const decoded = auth.isValidToken('Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34');
         t.equal(decoded.sub, 'test@test.com');
         t.end();
     } catch (err) {
@@ -71,7 +71,7 @@ tape.test('If valid token with altered secret then return decoded token', functi
 tape.test('If valid token with Bearer keyword then return decoded token', function(t) {
 
     try {
-        const decoded = auth.isValidToken('Bearer ' + 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34');
+        const decoded = auth.isValidToken('Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34');
         t.equal(decoded.sub, 'test@test.com');
         t.end();
     } catch (err) {
@@ -163,7 +163,7 @@ tape.test('if valid token and valid scope then resolve decoded token', function(
         ]
     };
 
-    const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34', {
+    const authPromise = auth.authenticate('Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34', {
         scope: ['admin'],
         rule: auth.RULE.NONE
     });
@@ -179,7 +179,7 @@ tape.test('if valid token and valid scope then resolve decoded token', function(
 
 tape.test('if invalid token and valid scope then reject', function(t) {
 
-    const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34' + 'foo', {
+    const authPromise = auth.authenticate('Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34' + 'foo', {
         scope: ['tester'],
         rule: auth.RULE.NONE
     });
@@ -196,7 +196,7 @@ tape.test('if invalid token and valid scope then reject', function(t) {
 
 tape.test('if valid token and invalid scope then reject', function(t) {
 
-    const authPromise = auth.authenticate('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34', {
+    const authPromise = auth.authenticate('Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34', {
         scope: ['admin']
     });
 
@@ -208,4 +208,16 @@ tape.test('if valid token and invalid scope then reject', function(t) {
         t.equal(err.code, '403');
         t.end();
     });
+});
+
+tape.test('if Bearer prefix is missing then reject', function(t) {
+    try {
+        auth.isValidToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwic2NvcGUiOlsidGVzdGVyIl19.ZzBZRdxQHFemCW2TwwFRn8Jk-uWt-OLtsi6O5pWpM34');
+
+        t.fail('didn\'t throw error');
+        t.end();
+    } catch (err) {
+        t.equal(err.code, '401');
+        t.end();
+    }
 });

--- a/test/mock-context-test.js
+++ b/test/mock-context-test.js
@@ -1,5 +1,5 @@
 const tape = require('tape');
-const Error = require('../lib/error');
+const FoundationError = require('../lib/error');
 const Context = require('../lib/test/context');
 
 tape.test('Should succeed with expected result provided', function(t) {
@@ -25,35 +25,40 @@ tape.test('Should succeed with callback provided', function(t) {
 });
 
 tape.test('Should fail with expected error provided', function(t) {
-    const mock = Context.assertFail(t, new Error('999', 'Expected error'));
+    const mock = Context.assertFail(t, new FoundationError('999', 'Expected error'));
     t.plan(2);
-    mock.fail(new Error('999', 'Expected error'));
+    mock.fail(new FoundationError('999', 'Expected error'));
 });
 
 tape.test('Should fail with expected error and callback provided', function(t) {
-    const mock = Context.assertFail(t, new Error('999', 'Expected error'), function(error) {
-        t.same(error, new Error('999', 'Expected error'), 'Callback called');
+    const mock = Context.assertFail(t, new FoundationError('999', 'Expected error'), function(error) {
+        t.same(error, new FoundationError('999', 'Expected error'), 'Callback called');
     });
     t.plan(3);
-    mock.fail(new Error('999', 'Expected error'));
+    mock.fail(new FoundationError('999', 'Expected error'));
 });
 
 tape.test('Should fail with expected error and callback provided', function(t) {
     const mock = Context.assertFail(t, function(error) {
-        t.same(error, new Error('999', 'Expected error'), 'Callback called');
+        t.same(error, new FoundationError('999', 'Expected error'), 'Callback called');
     });
     t.plan(2);
-    mock.fail(new Error('999', 'Expected error'));
+    mock.fail(new FoundationError('999', 'Expected error'));
 });
 
 tape.test('Should succeed with done called', function(t) {
-    const mock = Context.assertFail(t, new Error('999', 'Expected error'));
+    const mock = Context.assertFail(t, new FoundationError('999', 'Expected error'));
     t.plan(2);
-    mock.done(new Error('999', 'Expected error'));
+    mock.done(new FoundationError('999', 'Expected error'));
 });
 
 tape.test('Should succeed with done called', function(t) {
     const mock = Context.assertSucceed(t, {result:"result"});
     t.plan(2);
     mock.done(null, {result:"result"});
+});
+
+tape.test('Should assert that two identical vanilla errors are equal', function(t) {
+    const mock = Context.assertFail(t, new Error('Expected error'));
+    mock.fail(new Error('Expected error'));
 });

--- a/test/mock-context-test.js
+++ b/test/mock-context-test.js
@@ -62,3 +62,10 @@ tape.test('Should assert that two identical vanilla errors are equal', function(
     const mock = Context.assertFail(t, new Error('Expected error'));
     mock.fail(new Error('Expected error'));
 });
+
+tape.test('Should fail assertion if two vanilla errors are not the same', function(t) {
+    t.same = t.notSame; // inverse assertion behaviour in context to show that its assertion did fail
+    const mock = Context.assertFail(t, new Error('Expected error'));
+    // mock is set to fail with error of different message and type, meaning that similarity assertion by Context should fail
+    mock.fail(new RangeError('Unexpected error'));
+});


### PR DESCRIPTION
- [x] Issue exists - #32 
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Enforced `Bearer` token type, as this is not backwards compatible, this will bump version to v3.